### PR TITLE
reset class id dictionary on load

### DIFF
--- a/unityparser/composer.py
+++ b/unityparser/composer.py
@@ -22,3 +22,8 @@ class Composer(YamlComposer):
             if node == v:
                 return k
         raise ComposerError("Expected anchor to be present for node")
+
+    def get_extra_anchor_data_from_node(self, anchor):
+        if anchor in self.extra_anchor_data:
+            return self.extra_anchor_data[anchor]
+        return ''

--- a/unityparser/constants.py
+++ b/unityparser/constants.py
@@ -25,8 +25,9 @@ class UnityClassIdMap:
 class UnityClass:
     __class_id = ''
 
-    def __init__(self, anchor):
+    def __init__(self, anchor, extra_anchor_data):
         self.anchor = anchor
+        self.extra_anchor_data = extra_anchor_data
 
     def update_dict(self, d):
         # replace and append current object attributes to self dict
@@ -38,6 +39,7 @@ class UnityClass:
         # return a copy of the objects attributes but the ones we don't want
         d = copy(self.__dict__)
         del d['anchor']
+        del d['extra_anchor_data']
         return d
 
 

--- a/unityparser/constants.py
+++ b/unityparser/constants.py
@@ -7,6 +7,10 @@ lock = RLock()
 
 class UnityClassIdMap:
     __class_id_map = {}
+    
+    @classmethod
+    def reset(self):
+        UnityClassIdMap.__class_id_map.clear()
 
     @classmethod
     def get_or_create_class_id(cls, classid, classname):

--- a/unityparser/dumper.py
+++ b/unityparser/dumper.py
@@ -11,6 +11,8 @@ VERSION = (1, 1)
 
 class UnityDumper(Emitter, Serializer, Representer, Resolver):
 
+    extra_anchor_data = {}
+
     def __init__(self, stream,
                  default_style=None, default_flow_style=False,
                  canonical=None, indent=None, width=None,
@@ -36,6 +38,7 @@ def represent_unity_class(dumper, instance):
     node = dumper.represent_mapping('{}{}'.format(UNITY_TAG_URI, instance.__class_id), data, False)
     # UNITY: set MappingNode anchor and all set all it's descendants anchors to None
     dumper.anchors[node] = instance.anchor
+    dumper.extra_anchor_data[instance.anchor] = instance.extra_anchor_data
     for key, value in node.value:
         dumper.anchor_node(key)
         dumper.anchor_node(value)

--- a/unityparser/emitter.py
+++ b/unityparser/emitter.py
@@ -66,6 +66,7 @@ class Emitter(YamlEmitter):
             # UNITY: tag and anchor appearance order swithced
             self.process_tag()
             self.process_anchor('&')
+            self.process_anchor_extra()
             if isinstance(self.event, ScalarEvent):
                 self.expect_scalar()
             elif isinstance(self.event, SequenceStartEvent):
@@ -195,3 +196,8 @@ class Emitter(YamlEmitter):
                     start += 1
             end += 1
         self.write_indicator('"', False)
+
+    def process_anchor_extra(self):
+        if self.event.anchor is None or self.event.anchor not in self.extra_anchor_data:
+            return
+        self.write_indicator(self.extra_anchor_data[self.event.anchor], False)

--- a/unityparser/loader.py
+++ b/unityparser/loader.py
@@ -50,7 +50,8 @@ def construct_unity_class(loader, tag_suffix, node):
 
     cls = UnityClassIdMap.get_or_create_class_id(classid, classname)
     anchor = loader.get_anchor_from_node(node)
-    value = cls(anchor)
+    extra_anchor_data = loader.get_extra_anchor_data_from_node(anchor)
+    value = cls(anchor, extra_anchor_data)
     value.update_dict(loader.construct_mapping(class_attributes_node, deep=True))
     return value
 

--- a/unityparser/parser.py
+++ b/unityparser/parser.py
@@ -5,6 +5,9 @@ from yaml.tokens import DocumentEndToken, StreamEndToken, DocumentStartToken, St
 
 class Parser(YamlParser):
 
+    # UNITY: used to store data after the anchor
+    extra_anchor_data = {}
+
     def parse_document_start(self):
 
         # Parse any extra document end indicators.

--- a/unityparser/scanner.py
+++ b/unityparser/scanner.py
@@ -1,4 +1,5 @@
 from yaml.scanner import Scanner as YamlScanner
+from yaml.tokens import AnchorToken
 
 
 class Scanner(YamlScanner):
@@ -28,3 +29,31 @@ class Scanner(YamlScanner):
             # UNITY: keep track of previous tokens
             self.prev_tokens.append(self.tokens.pop(0))
             return self.prev_tokens[-1]
+
+    def fetch_anchor(self):
+        super().fetch_anchor()
+
+        # after fetching the anchor, we need to determine if we are at
+        # end of line, or if there are further tokens past the anchor.
+        # If at the end of line, we can continue as normal.  If there
+        # are more tokens (like the word 'stripped') then we need
+        # to grab that token and save it, then we can continue
+        if self.peek() in '\r\n\x85\u2028\u2029':
+            return
+
+        # pop off the old token because we will replace it with a new
+        # one that contains original anchor name along with extra
+        # stuff on the anchor line that Unity puts there
+        #token = self.tokens.pop()
+        extra_anchor_data = ''
+        while self.peek() not in '\r\n\x85\u2028\u2029':
+            ch = self.peek()
+            self.forward()
+            extra_anchor_data += ch
+
+        # this point we can construct this anchor with the anchor
+        # name and all of the extra tokens after the anchor
+        # new_token = AnchorToken(new_anchor_name, token.start_mark, self.get_mark())
+        # self.tokens.append(new_token)
+        self.extra_anchor_data[self.tokens[-1].value] = extra_anchor_data
+        return

--- a/unityparser/tests/fixtures/MultiDoc.asset
+++ b/unityparser/tests/fixtures/MultiDoc.asset
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
+--- !u!129 &100100000
 Prefab:
   m_ObjectHideFlags: 1
   serializedVersion: 2

--- a/unityparser/tests/fixtures/UnityExtraAnchorData.prefab
+++ b/unityparser/tests/fixtures/UnityExtraAnchorData.prefab
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!54 &54222192069566592
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686706870913700820}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 1
+--- !u!114 &3105306602046500935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686706870913700820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 494b1123d3fe94745863d9b147de0386, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  showDebug: 0
+  collectComponent: {fileID: 1203525732496649799}
+  rigidbody: {fileID: 0}
+--- !u!114 &3126906273433738648 stripped
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686706870913700820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Name: 
+  m_Script: {fileID: 11500000, guid: 42b72ed05b5abd14aa308ff8fde1fbf5, type: 3}

--- a/unityparser/tests/test_unity_document.py
+++ b/unityparser/tests/test_unity_document.py
@@ -19,3 +19,12 @@ class TestUnityDocument:
         doc.dump_yaml(file_path=str(dumped_file_path))
 
         assert base_file_path.read() == dumped_file_path.read()
+
+    def test_unity_extra_anchor_data(self, fixtures, tmpdir):
+        base_file_path = py.path.local(fixtures['UnityExtraAnchorData.prefab'])
+        doc = UnityDocument.load_yaml(str(base_file_path))
+        dumped_file_path = tmpdir.join('UnityExtraAnchorData.prefab')
+        doc.dump_yaml(file_path=str(dumped_file_path))
+
+        assert base_file_path.read() == dumped_file_path.read()
+

--- a/unityparser/utils.py
+++ b/unityparser/utils.py
@@ -2,6 +2,7 @@ import yaml
 
 from .dumper import UnityDumper
 from .loader import UnityLoader
+from .constants import UnityClassIdMap
 
 UNIX_LINE_ENDINGS = '\n'
 
@@ -36,6 +37,7 @@ class UnityDocument:
 
     @classmethod
     def load_yaml(cls, file_path):
+        UnityClassIdMap.reset()
         with open(file_path, newline='') as fp:
             data = [d for d in yaml.load_all(fp, Loader=UnityLoader)]
             # use document line endings if no mixed lien endings found, else default to linux


### PR DESCRIPTION
The class id dictionary wasn't reset between loads.  So if you loaded multiple unity YAML documents that had the same class id, the written file would be incorrect.  I've modified one of the ids in the multi doc file to have the same id as one of the blocks in the single asset file.  Without this change, making this change in the multidoc example will fail the tests (if you run them  both)