### PR TITLE
fix(multifile) Fix conflicts parsing multiple files

### DIFF
--- a/unityparser/constants.py
+++ b/unityparser/constants.py
@@ -7,7 +7,11 @@ lock = RLock()
 
 class UnityClassIdMap:
     __class_id_map = {}
-
+    
+    @classmethod
+    def reset(self):
+        UnityClassIdMap.__class_id_map.clear()
+        
     @classmethod
     def get_or_create_class_id(cls, classid, classname):
         lock.acquire()

--- a/unityparser/tests/fixtures/MultiDoc.asset
+++ b/unityparser/tests/fixtures/MultiDoc.asset
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
+--- !u!129 &100100000
 Prefab:
   m_ObjectHideFlags: 1
   serializedVersion: 2

--- a/unityparser/utils.py
+++ b/unityparser/utils.py
@@ -2,6 +2,7 @@ import yaml
 
 from .dumper import UnityDumper
 from .loader import UnityLoader
+from .constants import UnityClassIdMap
 
 UNIX_LINE_ENDINGS = '\n'
 
@@ -36,6 +37,7 @@ class UnityDocument:
 
     @classmethod
     def load_yaml(cls, file_path):
+        UnityClassIdMap.reset()
         with open(file_path, newline='') as fp:
             data = [d for d in yaml.load_all(fp, Loader=UnityLoader)]
             # use document line endings if no mixed lien endings found, else default to linux


### PR DESCRIPTION
The class dictionary wasn't getting reset between loading
documents which would result in incorrect scalars getting
written out when the document was saved.  The multidoc
file was modified to include an id that matches the singledoc
id in order to test this issue