### PR TITLE
fix(parsing) Fix parsing anchors with extra data

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,3 @@ You have to make sure to convert every modified/added value(or _dict_ key) in th
 
 Text scalars which are single or double quoted that span multiple lines are not being dumped exactly as Unity does. There's a difference in the maximum length allowed per line and the logic to wrap them.
 
-**Unity scenes are not yet supported**. It shouldn't require much effort to do so.

--- a/unityparser/composer.py
+++ b/unityparser/composer.py
@@ -7,6 +7,9 @@ class Composer(YamlComposer):
         # Drop the DOCUMENT-START event.
         self.get_event()
 
+        # UNITY: used to store data after the anchor
+        self.extra_anchor_data = {}
+
         # Compose the root node.
         node = self.compose_node(None, None)
 
@@ -22,3 +25,8 @@ class Composer(YamlComposer):
             if node == v:
                 return k
         raise ComposerError("Expected anchor to be present for node")
+
+    def get_extra_anchor_data_from_node(self, anchor):
+        if anchor in self.extra_anchor_data:
+            return self.extra_anchor_data[anchor]
+        return ''

--- a/unityparser/constants.py
+++ b/unityparser/constants.py
@@ -21,8 +21,9 @@ class UnityClassIdMap:
 class UnityClass:
     __class_id = ''
 
-    def __init__(self, anchor):
+    def __init__(self, anchor, extra_anchor_data):
         self.anchor = anchor
+        self.extra_anchor_data = extra_anchor_data
 
     def update_dict(self, d):
         # replace and append current object attributes to self dict
@@ -34,6 +35,7 @@ class UnityClass:
         # return a copy of the objects attributes but the ones we don't want
         d = copy(self.__dict__)
         del d['anchor']
+        del d['extra_anchor_data']
         return d
 
 

--- a/unityparser/dumper.py
+++ b/unityparser/dumper.py
@@ -4,6 +4,7 @@ from yaml.serializer import Serializer
 from .constants import UNITY_TAG_URI, UnityClass, OrderedFlowDict
 from .emitter import Emitter
 from .resolver import Resolver
+from .serializer import Serializer
 
 UNITY_TAG = {'!u!': UNITY_TAG_URI}
 VERSION = (1, 1)
@@ -36,6 +37,7 @@ def represent_unity_class(dumper, instance):
     node = dumper.represent_mapping('{}{}'.format(UNITY_TAG_URI, instance.__class_id), data, False)
     # UNITY: set MappingNode anchor and all set all it's descendants anchors to None
     dumper.anchors[node] = instance.anchor
+    dumper.extra_anchor_data[instance.anchor] = instance.extra_anchor_data
     for key, value in node.value:
         dumper.anchor_node(key)
         dumper.anchor_node(value)

--- a/unityparser/emitter.py
+++ b/unityparser/emitter.py
@@ -66,6 +66,7 @@ class Emitter(YamlEmitter):
             # UNITY: tag and anchor appearance order swithced
             self.process_tag()
             self.process_anchor('&')
+            self.process_anchor_extra()
             if isinstance(self.event, ScalarEvent):
                 self.expect_scalar()
             elif isinstance(self.event, SequenceStartEvent):
@@ -195,3 +196,8 @@ class Emitter(YamlEmitter):
                     start += 1
             end += 1
         self.write_indicator('"', False)
+
+    def process_anchor_extra(self):
+        if self.event.anchor is None or self.event.anchor not in self.extra_anchor_data:
+            return
+        self.write_indicator(self.extra_anchor_data[self.event.anchor], False)

--- a/unityparser/loader.py
+++ b/unityparser/loader.py
@@ -50,7 +50,8 @@ def construct_unity_class(loader, tag_suffix, node):
 
     cls = UnityClassIdMap.get_or_create_class_id(classid, classname)
     anchor = loader.get_anchor_from_node(node)
-    value = cls(anchor)
+    extra_anchor_data = loader.get_extra_anchor_data_from_node(anchor)
+    value = cls(anchor, extra_anchor_data)
     value.update_dict(loader.construct_mapping(class_attributes_node, deep=True))
     return value
 

--- a/unityparser/serializer.py
+++ b/unityparser/serializer.py
@@ -1,0 +1,29 @@
+from yaml.serializer import Serializer as YamlSerializer
+from yaml.events import DocumentStartEvent, DocumentEndEvent
+
+# override serialzier class to store data needed
+# for extra data on anchor lines
+class Serializer(YamlSerializer):
+
+    def __init__(self, encoding=None,
+            explicit_start=None, explicit_end=None, version=None, tags=None):
+        super().__init__(encoding=encoding,
+            explicit_start=explicit_start, explicit_end=explicit_end, version=version,
+            tags=tags)
+        self.extra_anchor_data = {}
+
+    def serialize(self, node):
+        if self.closed is None:
+            raise SerializerError("serializer is not opened")
+        elif self.closed:
+            raise SerializerError("serializer is closed")
+        self.emit(DocumentStartEvent(explicit=self.use_explicit_start,
+            version=self.use_version, tags=self.use_tags))
+        self.anchor_node(node)
+        self.serialize_node(node, None, None)
+        self.emit(DocumentEndEvent(explicit=self.use_explicit_end))
+        self.serialized_nodes = {}
+        self.anchors = {}
+        self.extra_anchor_data = {}
+        self.last_anchor_id = 0
+

--- a/unityparser/tests/fixtures/UnityExtraAnchorData.prefab
+++ b/unityparser/tests/fixtures/UnityExtraAnchorData.prefab
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!54 &54222192069566592
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686706870913700820}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 1
+--- !u!114 &3105306602046500935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686706870913700820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 494b1123d3fe94745863d9b147de0386, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  showDebug: 0
+  collectComponent: {fileID: 1203525732496649799}
+  rigidbody: {fileID: 0}
+--- !u!114 &3126906273433738648 stripped
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8686706870913700820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Name: 
+  m_Script: {fileID: 11500000, guid: 42b72ed05b5abd14aa308ff8fde1fbf5, type: 3}

--- a/unityparser/tests/test_unity_document.py
+++ b/unityparser/tests/test_unity_document.py
@@ -19,3 +19,12 @@ class TestUnityDocument:
         doc.dump_yaml(file_path=str(dumped_file_path))
 
         assert base_file_path.read() == dumped_file_path.read()
+
+    def test_unity_extra_anchor_data(self, fixtures, tmpdir):
+        base_file_path = py.path.local(fixtures['UnityExtraAnchorData.prefab'])
+        doc = UnityDocument.load_yaml(str(base_file_path))
+        dumped_file_path = tmpdir.join('UnityExtraAnchorData.prefab')
+        doc.dump_yaml(file_path=str(dumped_file_path))
+
+        assert base_file_path.read() == dumped_file_path.read()
+


### PR DESCRIPTION
Unity will sometimes add extra data to the end of
the anchor lines.  This fix will allow those changes
to be properly read, parsed, and re-serialized.

Fixes #2