### PR TITLE
chore(deps): use mainstream package

### DIFF
--- a/requirements/publish.txt
+++ b/requirements/publish.txt
@@ -1,1 +1,1 @@
-git+https://github.com/sp-ricard-valverde/python-semantic-release.git@master#egg=python-semantic-release
+python-semantic-release>=7.29.0


### PR DESCRIPTION
Switch to official python-semantic-release publishing package now that
the required features for using deploy keys have been merged into their
main branch