### PR TITLE
Add support to parse scalars in the form `: <key>` with Empty value

### DIFF
--- a/unityparser/commands.py
+++ b/unityparser/commands.py
@@ -38,6 +38,10 @@ class UnityProjectTester:
                                 help='Dont\'t modify.',
                                 default=False,
                                 action='store_true')
+        top_parser.add_argument('--suffixes',
+                                help='Look for files with suffixes in this comma-separated list(default: ".asset,.unity,.prefab").',
+                                default='.asset,.unity,.prefab',
+                                action='store_true')
         try:
             self.options = top_parser.parse_args()
         except TypeError:
@@ -48,7 +52,7 @@ class UnityProjectTester:
 
     def test_no_yaml_is_modified(self):
         """
-        Recurse the whole project folder looking for '.asset' files, load and save them all, and check that
+        Recurse the whole project folder looking for serializable files, load and save them all, and check that
         there are no modifications
         """
         if self.options.dry_run:
@@ -59,7 +63,8 @@ class UnityProjectTester:
             print("Keep changes mode enabled: Changes to files will be kept.")
 
         project_path = Path(self.options.project_path)
-        asset_file_paths = [p for p in project_path.rglob('*.asset')]
+        suffixes = [f".{s.strip('.')}" for s in self.options.suffixes.split(',')]
+        asset_file_paths = [p for p in project_path.rglob('*') if p.suffix in suffixes]
         print("Found {} '.asset' files".format(len(asset_file_paths)))
 
         def is_path_included(path):
@@ -69,7 +74,7 @@ class UnityProjectTester:
         if self.options.exclude is not None:
             rexps = [re.compile(rexp) for rexp in self.options.exclude]
             valid_file_paths = [p for p in filter(is_path_included, asset_file_paths)]
-            print("Excluded {} '.asset' files".format(len(asset_file_paths) - len(valid_file_paths)))
+            print("Excluded {} files".format(len(asset_file_paths) - len(valid_file_paths)))
         else:
             valid_file_paths = asset_file_paths
 

--- a/unityparser/tests/fixtures/InvertedScalar.dll.meta
+++ b/unityparser/tests/fixtures/InvertedScalar.dll.meta
@@ -1,0 +1,69 @@
+fileFormatVersion: 2
+guid: 7b042741569854557813adece4fc66e7
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
+  - first:
+      Any:
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unityparser/tests/test_inverted_scalar.py
+++ b/unityparser/tests/test_inverted_scalar.py
@@ -1,0 +1,13 @@
+import py
+import pytest
+
+from unityparser.utils import UnityDocument
+
+
+class TestInvertedScalarLoading:
+
+    def test_inverted_scalar_loading_ok(self, fixtures, tmpdir):
+        base_file_path = py.path.local(fixtures['InvertedScalar.dll.meta'])
+        doc = UnityDocument.load_yaml(str(base_file_path))
+        assert doc.entry['PluginImporter']['platformData'][0]['first']['Any'] is None
+


### PR DESCRIPTION
It's a rare case that has been identified to happen to .dll.meta files and Unity staff flagged the issue as design, so
no hopes on them to fix this(https://github.com/socialpoint-labs/unity-yaml-parser/issues/32)

Although the loading of such documents is supported, serialization will *fix* the scalar value and produce a correct yaml