### PR TITLE
fix(ci): disable firstParent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          firstParent: false
 
   tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Prevent merge commits to be bypassed by commitlint's ci and
consequently not being added to the CHANGELOG