### PR TITLE
chore(dump): adding kwargs to dump_yaml 

### DIFF
--- a/unityparser/utils.py
+++ b/unityparser/utils.py
@@ -25,7 +25,7 @@ class UnityDocument:
     def entries(self):
         return self.data
 
-    def dump_yaml(self, file_path=None):
+    def dump_yaml(self, file_path=None, **kwargs):
         """
         :param file_path: If self.file_path is None, it must be passed
         :type file_path:
@@ -35,7 +35,7 @@ class UnityDocument:
         file_path = file_path or self.file_path
         assert_or_raise(file_path is not None, UnityDocumentError("file_path parameter must be passed"))
         with open(file_path, 'w', newline=self.newline) as fp:
-            dump_all(self.data, stream=fp, register=self.register)
+            dump_all(self.data, stream=fp, register=self.register, **kwargs)
 
     @classmethod
     def load_yaml(cls, file_path):


### PR DESCRIPTION
This is required to add extra arguments such as the line width. Unity internally does not split as soon as the default python yaml parser does. We have some files in VC that we modify with our tools and without the proper line width this makes our local repos dirty each time we apply some tooling.

```
import math
doc.dump_yaml(width=math.inf)
```