### PR TITLE
feat(deps)!: update pyyaml to 6.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,1 +1,1 @@
-PyYAML==5.4
+PyYAML==6.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='ricard.valverde@socialpoint.es',
     url='https://github.com/socialpoint-labs/unity-yaml-parser',
     license='MIT License',
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     packages=['unityparser'],
     keywords=['unity', 'yaml', 'parser', 'serializer'],
     install_requires=requirements.pop('base'),

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # requires = tox-conda
-envlist = py36,py37,py38
+envlist = py37,py38
 
 [testenv]
 # To prevent symlinks that can be broken when restoring CI cache


### PR DESCRIPTION
There is an issue with PyYAML caused by the release of cython 3.0.0 https://github.com/yaml/pyyaml/issues/724. It seems like updating to a newer PyYAML is the only path forward as the maintainers don't want to release a new 5.X version for risk of breaking things more for people. It looks like the major breaking change is that PyYAML now only supports Python3 in v6.0 and it looks like unityparser already requires Python >= 3.6 so I don't think there will be any code that needs to change. 