### PR TITLE
preserve formatting of floats in edge cases

### DIFF
--- a/unityparser/dumper.py
+++ b/unityparser/dumper.py
@@ -60,7 +60,15 @@ def represent_str(dumper, instance):
     return dumper.represent_scalar('tag:yaml.org,2002:str', instance, style=style)
 
 
+def represent_float(dumper, instance):
+    float_str = str(instance)
+    if 'e' in float_str:
+        float_str = format(instance, '.17f').rstrip('0')
+    return dumper.represent_scalar('tag:yaml.org,2002:float', float_str)
+
+
 Representer.add_multi_representer(UnityClass, represent_unity_class)
 Representer.add_representer(OrderedFlowDict, represent_ordered_flow_dict)
 Representer.add_representer(type(None), represent_none)
 Representer.add_representer(uniqstr, represent_str)
+Representer.add_representer(float, represent_float)

--- a/unityparser/tests/fixtures/MultiDoc.asset
+++ b/unityparser/tests/fixtures/MultiDoc.asset
@@ -58,6 +58,19 @@ MonoBehaviour:
   fullBlinks: 3
   interpolation: 4
   pieceType: 2
+  f1: 0.000001
+  f2: 0.0000001
+  f3: 0.00000001
+  f4: 0.000000001
+  f5: -0.7071068
+  f6: 0.7071068
+  f7: 0.00000011920929
+  f8: 0.231
+  f9: 0.0423
+  f10: 1e+10
+  f11: 1e+28
+  f12: 1e-11
+  f13: 1.1111111e-11
 --- !u!212 &212685313502090504
 SpriteRenderer:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
some floats would be written as scientific notation using the default representer. this will cause yaml to insert a `!!float` tag which is not recognized by unity.

for example: `0.000000001` --> `!!float 1e-9`