### PR TITLE
Add Property to Exclude Header Tags When Saving Unity .meta Files

### DIFF
--- a/unityparser/dumper.py
+++ b/unityparser/dumper.py
@@ -18,10 +18,11 @@ class UnityDumper(Emitter, Serializer, Representer, Resolver):
                  canonical=None, indent=None, width=None,
                  allow_unicode=None, line_break=None,
                  encoding=None, explicit_start=None, explicit_end=None,
-                 version=None, tags=None, sort_keys=True, register=None):
-        tags = tags or {}
-        tags.update(UNITY_TAG)
-        version = version or VERSION
+                 version=None, tags=None, sort_keys=True, register=None, is_meta_file=False):
+        if not is_meta_file:
+            tags = tags or {}
+            tags.update(UNITY_TAG)
+            version = version or VERSION
         Emitter.__init__(self, stream, canonical=canonical,
                          indent=indent, width=width,
                          allow_unicode=allow_unicode, line_break=line_break)

--- a/unityparser/utils.py
+++ b/unityparser/utils.py
@@ -113,7 +113,7 @@ def dump_all(documents, stream=None, default_style=None,
              canonical=None, indent=None, width=None,
              allow_unicode=None, line_break=None,
              encoding=None, explicit_start=None, explicit_end=None,
-             version=None, tags=None, sort_keys=True, register=None):
+             version=None, tags=None, sort_keys=True, register=None, is_meta_file=False):
     """
     Serialize a sequence of Python objects into a YAML stream.
     If stream is None, return the produced string instead.
@@ -132,7 +132,7 @@ def dump_all(documents, stream=None, default_style=None,
                          encoding=encoding, version=version, tags=tags,
                          explicit_start=explicit_start,
                          explicit_end=explicit_end,
-                         sort_keys=sort_keys, register=register)
+                         sort_keys=sort_keys, register=register, is_meta_file=is_meta_file)
     try:
         dumper.open()
         for data in documents:


### PR DESCRIPTION
## Description
This merge request introduces a new property to handle Unity meta files more efficiently during the save operation. Unity meta files do not utilize header tags; however, our current save functionality does not differentiate between file types. This update adds a property to identify Unity meta files specifically and ensures that header tags are not included upon saving these files.