### PR TITLE
Release 4.0

### DIFF
--- a/unityparser/dumper.py
+++ b/unityparser/dumper.py
@@ -19,9 +19,6 @@ class UnityDumper(Emitter, Serializer, Representer, Resolver):
                  allow_unicode=None, line_break=None,
                  encoding=None, explicit_start=None, explicit_end=None,
                  version=None, tags=None, sort_keys=True, register=None):
-        tags = tags or {}
-        tags.update(UNITY_TAG)
-        version = version or VERSION
         Emitter.__init__(self, stream, canonical=canonical,
                          indent=indent, width=width,
                          allow_unicode=allow_unicode, line_break=line_break)

--- a/unityparser/loader.py
+++ b/unityparser/loader.py
@@ -5,7 +5,7 @@ from .composer import Composer
 from .constants import UNITY_TAG_URI, OrderedFlowDict, UnityClassIdMap
 from .constructor import Constructor
 from .parser import Parser
-from .resolver import Resolver
+from .resolver import Resolver, SmartResolver
 
 
 class UpgradeVersionError(Exception):
@@ -38,6 +38,17 @@ class UnityLoader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
         Resolver.__init__(self)
 
 
+class SmartUnityLoader(Reader, Scanner, Parser, Composer, Constructor, SmartResolver):
+
+    def __init__(self, stream, register=None):
+        Reader.__init__(self, stream)
+        Scanner.__init__(self)
+        Parser.__init__(self)
+        Composer.__init__(self)
+        Constructor.__init__(self, register)
+        SmartResolver.__init__(self)
+
+
 def construct_unity_class(loader, tag_suffix, node):
     try:
         classid = tag_suffix
@@ -66,3 +77,5 @@ def construct_yaml_map(loader, node):
 
 UnityLoader.add_constructor('tag:yaml.org,2002:map', construct_yaml_map)
 UnityLoader.add_multi_constructor(UNITY_TAG_URI, construct_unity_class)
+SmartUnityLoader.add_constructor('tag:yaml.org,2002:map', construct_yaml_map)
+SmartUnityLoader.add_multi_constructor(UNITY_TAG_URI, construct_unity_class)

--- a/unityparser/parser.py
+++ b/unityparser/parser.py
@@ -8,6 +8,7 @@ class Parser(YamlParser):
     def __init__(self):
         super(Parser, self).__init__()
         self.parsing_inverted_scalar = False
+        self.non_default_tags = None
 
     def parse_document_start(self):
 
@@ -22,6 +23,9 @@ class Parser(YamlParser):
             # UNITY: only process directives(version and tags) on the first document
             if self.check_prev_token(StreamStartToken):
                 version, tags = self.process_directives()
+                # UNITY: keep track of tags explicitly defined in the document
+                if self.non_default_tags is None:
+                    self.non_default_tags = tags
             else:
                 version, tags = self.yaml_version, self.tag_handles.copy() if self.tag_handles else None
             if not self.check_token(DocumentStartToken):

--- a/unityparser/resolver.py
+++ b/unityparser/resolver.py
@@ -18,17 +18,6 @@ class Resolver(BaseResolver):
 #                     |on|On|ON|off|Off|OFF)$''', re.X),
 #     list('yYnNtTfFoO'))
 
-Resolver.add_implicit_resolver(
-    'tag:yaml.org,2002:float',
-    re.compile(r'''^(?:[-+]?(?:0|[1-9][0-9]*)\.(?:[1-9]|[0-9][0-9]*[1-9])?)$''', re.X),
-    list('-+0123456789.'))
-
-Resolver.add_implicit_resolver(
-    'tag:yaml.org,2002:int',
-    # UNITY: Restrict to simple integer values
-    re.compile(r'''^(?:[-+]?(?:0|[1-9][0-9]*))$''', re.X),
-    list('-+0123456789'))
-
 # Resolver.add_implicit_resolver(
 #     'tag:yaml.org,2002:merge',
 #     re.compile(r'^(?:<<)$'),
@@ -60,3 +49,24 @@ Resolver.add_implicit_resolver(
     'tag:yaml.org,2002:yaml',
     re.compile(r'^(?:!|&|\*)$'),
     list('!&*'))
+
+
+class SmartResolver(Resolver):
+    """
+    A Resolver that tries to be smart about how Unity serializes int and float values, but it's known that does not
+    cover all cases.
+    """
+    pass
+
+
+SmartResolver.add_implicit_resolver(
+    'tag:yaml.org,2002:float',
+    re.compile(r'''^(?:[-+]?(?:0|[1-9][0-9]*)\.(?:[1-9]|[0-9][0-9]*[1-9])?)$''', re.X),
+    list('-+0123456789.'))
+
+SmartResolver.add_implicit_resolver(
+    'tag:yaml.org,2002:int',
+    # UNITY: Restrict to simple integer values
+    re.compile(r'''^(?:[-+]?(?:0|[1-9][0-9]*))$''', re.X),
+    list('-+0123456789'))
+

--- a/unityparser/tests/fixtures/MetaFileWithoutTags.meta
+++ b/unityparser/tests/fixtures/MetaFileWithoutTags.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b042741569854557813adece4fc66e7
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []

--- a/unityparser/tests/test_scalar_value_types.py
+++ b/unityparser/tests/test_scalar_value_types.py
@@ -1,14 +1,13 @@
 import py
-import pytest
 
-from unityparser.utils import UnityDocument, UnityDocumentError
+from unityparser.utils import UnityDocument
 
 
-class TestScalarValueTypes:
+class TestSmartScalarValueTypes:
 
     def test_types(self, fixtures):
         base_file_path = py.path.local(fixtures['MultipleTypesDoc.asset'])
-        doc = UnityDocument.load_yaml(str(base_file_path))
+        doc = UnityDocument.load_yaml(str(base_file_path), try_preserve_types=True)
         multi_types = doc.entry
 
         count_map = {'int': 0, 'str': 0, 'float': 0}
@@ -34,7 +33,7 @@ class TestScalarValueTypes:
 
     def test_sum_int_type(self, fixtures):
         base_file_path = py.path.local(fixtures['MultipleTypesDoc.asset'])
-        doc = UnityDocument.load_yaml(str(base_file_path))
+        doc = UnityDocument.load_yaml(str(base_file_path), try_preserve_types=True)
         multi_types = doc.entry
 
         multi_types.scalar_int_001 += 1

--- a/unityparser/tests/test_unity_document.py
+++ b/unityparser/tests/test_unity_document.py
@@ -30,6 +30,14 @@ class TestUnityDocumentSerialization:
 
         assert base_file_path.read() == dumped_file_path.read()
 
+    def test_preserve_missing_yaml_tags_ok(self, fixtures, tmpdir):
+        base_file_path = py.path.local(fixtures['MetaFileWithoutTags.meta'])
+        doc = UnityDocument.load_yaml(str(base_file_path))
+        dumped_file_path = tmpdir.join('MetaFileWithoutTags.meta')
+        doc.dump_yaml(file_path=str(dumped_file_path))
+
+        assert base_file_path.read() == dumped_file_path.read()
+
 
 class TestUnityDocumentFilters:
 


### PR DESCRIPTION
- Preserve YAML header version and custom tags. If the loaded document does not contain YAML version or a custom header tag(such as the unity tag) they won't be serialized back. This is known to apply to `.meta` files.

Closes #69 

- Deserialize all scalar data to Python `string` types by default. This will prevent serializing back unchanged data parsed as int or float in a different unsupported format. Also added the possibility to keep the previous loading behavior, documented in the corresponding commit message.

Closes #66 

This PR contains BREAKING CHANGES. Check the commit messages for instructions on how to address them.